### PR TITLE
Blog post for Opal 0.10 release

### DIFF
--- a/source/blog/2016-06-23-opal-0-10.html.md
+++ b/source/blog/2016-06-23-opal-0-10.html.md
@@ -1,0 +1,18 @@
+---
+title: "Opal 0.10: Rack 2 compatibility, improved keyword argument support, better source maps, and a whole lot more"
+date: 2016/06/23
+author: Jared White
+---
+
+Opal is now officially on the 0.10.x release path. Thanks to all the [contributors to Opal](https://github.com/opal/opal/graphs/contributors?from=2016-01-14&to=2016-06-23&type=c) who've worked hard to make this release possible. Some highlights from the latest release:
+
+* Improvements to source maps
+* Updates to methods in Array, Ennumerable, and Module for RubySpec compliance
+* Rack v2 compatibility
+* Support for keyword arguments as lambda parameters, as well as keyword splats
+* Some IO enhancements to better work with Node.js
+<!--preview-->
+
+### Read the Changelog for further details
+
+As always, Opal 0.10 includes many bug fixes and improvements to the internals of the Opal libraries, so be sure to [read the changelog](https://github.com/opal/opal/blob/master/CHANGELOG.md#0100---rc) for further details.


### PR DESCRIPTION
Changelog link will need to be adjusted when the final 0.10 release is done. Let me know if there's anything else I should highlight. Also maybe should add a link to the final Rubygems release page when that's ready.