### PR TITLE
Fix typo in the Rack tutorial

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -72,7 +72,7 @@ require 'opal-sprockets'
 
 run Opal::Server.new { |server|
   # the name of the ruby file to load. To use more files they must be required from here (see app)
-  server.main = 'application'
+  server.main = 'hello_world.js.rb'
   # the directory where the code is (add to opal load path )
   server.append_path 'app'
 }


### PR DESCRIPTION
I've tried [the Rack turorial](http://opalrb.org/#getting-started-rails), but needed a small fix to get it work.