### PR TITLE
Update guides

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -101,7 +101,7 @@ Then start the server with `bundle exec rackup` and visit [http://localhost:9292
 
 ## Getting Started: Rails
 
-Add `opal-rails` to your `Gemfile` or build your Rails app with Opal support: `rails new -j opal`
+Add `opal-rails` to your Rails app's `Gemfile`:
 
 ```ruby
 gem 'opal-rails'

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -72,7 +72,7 @@ Setup the Opal rack-app in your `config.ru` as follows:
 ```ruby
 require 'opal-sprockets'
 
-run Opal::Server.new { |server|
+run Opal::Sprockets::Server.new { |server|
   # the name of the ruby file to load. To use more files they must be required from here (see app)
   server.main = 'hello_world.js.rb'
   # the directory where the code is (add to opal load path )


### PR DESCRIPTION
This replaces deprecated calls to `Opal::Server` with `Opal::Sprockets::Server`. It also removes references to the `rails -j` option, which is no longer available. 