### PR TITLE
Fix code block CSS

### DIFF
--- a/lib-sass/application.scss
+++ b/lib-sass/application.scss
@@ -137,6 +137,10 @@ pre {
 
   font-family: Menlo, Consolas, "Courier New", monospace;
 
+  code {
+    display: inline-block;
+  }
+
   &.highlight {
     background-color: #f7f7f9;
   }


### PR DESCRIPTION
Hi, I found that an indentation the first line in a code block is a bit strange, so this PR fixes it.

For example, see <http://opalrb.com/>.

## Before

![image](https://user-images.githubusercontent.com/473530/56477912-a4ff6480-64e5-11e9-81a4-40cadb82eee8.png)

## After

![image](https://user-images.githubusercontent.com/473530/56477917-ae88cc80-64e5-11e9-97d4-f72cfc7ec893.png)

