### PR TITLE
Remove Google Analytics

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -6,15 +6,6 @@
 
   <title><%= current_page.data.title || "Opal: Ruby to Javascript compiler" %></title>
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-35688734-1"></script>
-  <script>
-    window.dataLayer || (window.dataLayer = []);
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-35688734-1');
-  </script>
-
   <%= stylesheet_link_tag "application" %>
   <%# See: https://ionicons.com/v2/ %>
   <%= stylesheet_link_tag "//code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css" %>


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/