### PR TITLE
Fix instructions to get started with Rack

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -85,10 +85,10 @@ puts user.admin?
 
 ## Getting Started: Rack
 
-Add `opal` and `rack` to your `Gemfile`.
+Add `opal`, `rack` and `rackup` to your `Gemfile`.
 
 ```shell
-bundle add opal rack
+bundle add opal rack rackup
 ```
 
 Setup the Opal rack-app in your `config.ru` as follows:


### PR DESCRIPTION
`rack` 3.0 no longer includes `rackup`. It must be required explicitly. 

```
> $ bundle exec rackup
bundler: failed to load command: rackup (/Users/wilson/.asdf/installs/ruby/3.2.2/bin/rackup)
/Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/rubygems_integration.rb:308:in `block in replace_bin_path': can't find executable rackup for gem rackup. rackup is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/rubygems_integration.rb:336:in `block in replace_bin_path'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/bin/rackup:25:in `<top (required)>'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/cli/exec.rb:58:in `load'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/cli/exec.rb:58:in `kernel_load'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/cli.rb:492:in `exec'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/cli.rb:28:in `start'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.19/exe/bundle:37:in `block in <top (required)>'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.19/exe/bundle:29:in `<top (required)>'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/bin/bundle:25:in `load'
  from /Users/wilson/.asdf/installs/ruby/3.2.2/bin/bundle:25:in `<main>'
```

https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#binrackup-rackserver-rackhandlerand--racklobster-were-moved-to-a-separate-gem